### PR TITLE
Shared folders (en, it)

### DIFF
--- a/administrator-manual/en/shared_folder.rst
+++ b/administrator-manual/en/shared_folder.rst
@@ -1,114 +1,143 @@
+.. _shared_folders-section:
+
+.. index:: shared folder
+   single: HTTP
+   single: SMB
+   single: CIFS
+
 ==============
 Shared folders
 ==============
 
-A shared folder is a resource on the system which can be
-accessed according to services installed on the system and permissions set
-by this module.
+A *shared folder* is a place where files can be accessed by a group of
+people using different methods, or *protocols*.  Since |product| is a
+modular system, the actual methods depends on what modules have been
+installed.
 
-Create new / edit
+The available methods/protocols are:
+
+* Web access (HTTP)
+* Samba (SMB/CIFS)
+
+Access privileges
 -----------------
 
-Depending on the services installed on your system you will see
-several tabs.
+A shared folder is always owned by a group of users (:guilabel:`Owning
+group`). Each member of the group is allowed to read the folder
+contents. Optionally the group can be entitled to modify the folder
+contents and the read permission can be extended to everyone accessing the
+system.  This simple permission model is based on the traditional UNIX
+file system permissions. 
 
-General
-^^^^^^^
-
-Name
-    The name of the shared folder. It can only contain lower case letters,
-    numbers, dots, dashes and underscores. The maximum length of the name is 12 characters.
-
-Description
-    Optional field for a brief description of the shared folder.
-
-Group owner
-    The owning group of the shared folder, only members of the
-    group can access the folder.
-
-Allow writing to the group owner
-    Allow write access to members of the owning group.
-
-Allow read access to all
-    Read access to anyone who connects to the system, as well as
-    public networks.
-
-ACL
-^^^
-
-The Access Control List allows specifing access permissions to the
-shared folder for each users or groups, in addition to those of the
-group owner.
-
-Read
-    Allow or deny read access to the user or group selected.
-
-Write 
-    Allow or deny the access in writing to the user or group 
-    selected.
+Access privileges can be refined further with the :guilabel:`ACL` tab,
+allowing individual users and other groups to gain read and write
+permissions.  This extended permission model is based on the POSIX ACL
+specification.
 
 
-Delete
-------
+Web access
+----------
 
-Removes the folder and all its contents. *The action is not
-reversible!* The only way to recover the contents of a folder shared
-that as been removed is to restore a backup.
+The :guilabel:`Web access` method allows the connection of a web
+browser to a shared folder using the HTTP protocol.  Web resources
+are identified by a string, the Uniform Resource Locator, or URL.
 
-Reset permissions
------------------
+For instance, if ``docs`` is the name of the shared folder, the URLs
+that allow the access to it could be: ::
 
-Set the group owner and ACLs configured using this module
-on all files in the folder. The operation will be performed recursively on
-all files and subfolders in the shared folder.
+    http://192.168.1.1/docs
+    https://192.168.1.1/docs
+    http://myserver/docs
+    http://www.domain.com/docs
+    http://docs.domain.com/
+
+Each URL has three components:
+
+* protocol (``http://`` or ``https://``),
+* host name (``192.168.1.1``, ``myserver``, ``www.domain.com``),
+* path (``docs``).
+
+The :guilabel:`Web address` radio group defines the "path"
+component. 
+
+* :guilabel:`Folder name` is the default, the same as the shared
+  folder name, as ``docs`` in the example above.
+
+* :guilabel:`Web site root` means no path at all. For instance
+  ``http://docs.domain.com``.
+
+* :guilabel:`Custom` means an alternative name, to be detailed.
+
+The :guilabel:`Virtual host` selector lists all :guilabel:`Server
+alias` defined under the :guilabel:`DNS` page. "Any" means the host
+part is not considered to map the URL to the shared folder.
+
+The web access is anonymous and read-only. There are some options that
+can be tweaked to restrict the access.
+
+* :guilabel:`Allow access from trusted networks only`, restricts the
+  access by looking at the IP address of the client,
+
+* :guilabel:`Protect by password`, requires an unique password to gain read access (to be specified here),
+
+* :guilabel:`Require SSL encrypted connection`.
 
 
-Web access 
-^^^^^^^^^^
+Configuring a web application
+-----------------------------
 
-Enables access to the shared folder from the web.
+The :guilabel:`Allow .htaccess and write permissions overrides`
+check box activates a special Apache configuration designed to host a
+simple web application on a shared folder.  It allows overriding the
+default Apache configuration and grants Apache the write permissions
+on specific sub-directories.
 
-Virtual Host 
-    Allows you to choose which host name is available on the shared
-    folder. The list comes from the card "Server Alias" in the
-    module "DNS and DHCP."
+.. warning:: If a shared folder contains executable code, such as PHP
+             scripts, user permissions and security implications must
+             be evaluated carefully.
 
-Web address (URL)
-    Defines the web address on which the resource is available. 
+If the check box is enabled 
 
-Allow access only from local networks 
-    If only enabled, restricts access to the resource only to local
-    networks.
+* any file named :file:`.htaccess` is loaded as `configuration for
+  Apache <http://httpd.apache.org/docs/2.2/howto/htaccess.html>`_.
 
-Require a password 
-    The access to the resource from the web requires no
-    authentication. Enable this option to require a password: specify
-    it in the field below.
+* a text file named :file:`.htwritable` positioned in the root level of the
+  shared folder may contain a list of sub-directories where Apache is
+  granted write permission.  The syntax of the file is one
+  sub-directory for each line.  Lines beginning with ``#`` are
+  comments.  When the content of :file:`.htwritable` changes, the
+  :guilabel:`Reset permission` button must be pressed again to
+  propagate the file system permissions.
+
+.. note:: Shared folders are a powerful tool but are not meant to be a
+          complete web hosting solution! For advanced Apache and
+          virtual host setups drop a ``.conf`` file under the
+          :file:`/etc/httpd/conf.d/` directory. Refer to the official
+          Apache documentation for this.
 
 
 Samba
-^^^^^ 
+-----
 
-Samba provides file and printer sharing to client SMB/CIFS (Windows
-File and Printer Sharing).
+SMB/CIFS is a widley adopted protocol that allows to share files
+across a computer network.  In a way similar to Web URLs above, the
+shared folder name becomes the SMB "share name".
 
-Enable Samba 
-     Enables access as a "shared folder" of Windows.
+For instance, the SMB network addresses of the ``docs`` share could be ::
 
-Network Recycle Bin 
-     Collects files deleted by this shared folder, so similar to the
-     Windows Recycle Bin.
+   \\192.168.1.1\docs
+   \\MYSERVER\docs
 
-Keep files of the same name 
-     If two files of the same name, they remain distinct in trash. By
-     disabling this option, the last one overwrites the previous year.
+Compatible SMB clients can be used to set special ACLs on a specific
+file or sub-directory. At any time, the :guilabel:`Reset permissions`
+button restores UNIX and POSIX permissions according to what is defined
+in the :guilabel:`General` and :guilabel:`ACL` pages.
 
-Guest Access 
-     A *guest user* is a user whose identification is failed because
-     it did not provide credentials or has provided incorrect. For
-     users or devices that act in this mode, you can grant the
-     following permissions:
+If the option :guilabel:`Network recycle bin` is enabled, removed
+files are actually moved into a special "wastebasket" directory. The
+:guilabel:`Keep omonym files` keeps distinct file names inside
+the wastebasket directory, preventing overwrites.
 
-     * None 
-     * Read-only 
-     * Read and write
+If :guilabel:`Guest access` is enabled, any provided authentication
+credentials are considered valid.
+

--- a/administrator-manual/it/shared_folder.rst
+++ b/administrator-manual/it/shared_folder.rst
@@ -1,164 +1,153 @@
-.. _shared-folder:
+.. _shared-folders-section:
+
+.. index:: cartelle condivise
+   single: HTTP
+   single: SMB
+   single: CIFS
 
 ==================
 Cartelle condivise
 ==================
 
-Le cartelle condivise sono uno strumento di |product| che permette di
-condividere file fra gli utenti del server.
+Una *cartella condivisa* è un posto dove i file sono accessibili da un
+gruppo di persone, utilizzando diversi metodi, o *protocolli*.  Poiché
+|product| è un sistema modulare, i metodi disponibili dipendono da
+quali moduli sono stati installati.
 
-Una cartella condivisa (conosciuta anche come i-bay) è una risorsa a
-cui si può accedere in base ai servizi installati nel sistema e ai
-permessi impostati da questo modulo.
+I metodi/protocolli disponibili sono:
 
+* Web access (HTTP)
+* Samba (SMB/CIFS)
 
-Installazione
-=============
+Permessi di accesso
+-------------------
 
-Per installare il pacchetto *Cartelle condivise* fare click su *Configurazione → Software center*. Mettere la
-spunta su *File server* e fare click sul pulsante *Avanti*. Verrano
-suggeriti dei pacchetti aggiuntivi da installare, selezionare quelli che
-si ritengono utili e confermare le modifiche al sistema facendo click
-sul pulsante applica.
+Una cartella condivisa appartiene sempre ad un gruppo di utenti
+(:guilabel:`Gruppo proprietario`). Ogni membro del gruppo può leggere
+i contenuti della cartella. Opzionalmente, al gruppo può essere
+concesso di modificare il contenuto della cartella e i permessi di
+lettura possono essere estesi a chiunque abbia accesso al sistema.
+Questo semplice modello di permessi è basato sui tradizionali permessi
+del filesystem di UNIX.
 
-Al termine dell’ installazione verrà mostrato in alto un messaggio che
-ci informa che l’operazione è stata completata correttamente.
+I permessi di accesso possono essere ulteriormente raffinati dalla
+scheda :guilabel:`ACL`, consentendo a singoli utenti o ad altri gruppi
+i permessi di lettura o scrittura.  Questo modello di permessi esteso
+è basato sulla specifica POSIX ACL.
 
-Gestione
-========
-
-Per configurare Cartelle condivise andare sulla sezione *Gestione →
-Cartelle condivise*.
-
-Si aprirà una pagina che mostra una tabella dove sono elencate tutte le
-cartelle condivise presenti sul sistema; qui è possibile creare una
-nuova cartella condivisa oppure modificarne o eliminarne una già
-esistente
-
-Creazione
-=========
-
-Cliccare sul pulsante *Crea nuovo* nella sezione *Cartelle condivise*.
-
-Generale
---------
-
-Nella scheda generale si deve inserire il nome della nuova cartella
-condivisa e una sua eventuale descrizione nei campi Nome e Descrizione.
-Scegliere il gruppo proprietario della cartella attraverso il menù a
-tendina. Lasciando tutti gli utenti autenticati la cartella sarà
-disponibile a tutti gli utenti registrati e autenticati sul sistema.
-
-E’ possibile scegliere i permessi di accesso alla cartella mettendo la
-spunta su consenti scrittura a gruppo proprietario e/o consenti lettura
-a tutti.
-
-Nome
-    Il nome della cartella condivisa può contenere solo lettere
-    minuscole, numeri, punti, trattini e underscore e deve iniziare con
-    una lettera. La lunghezza massima consentita del nome è 12
-    caratteri.
-
-Descrizione
-    Campo opzionale per una breve descrizione della cartella condivisa.
-
-Gruppo proprietario
-    Il gruppo proprietario della cartella condivisa, solo i membri del
-    gruppo potranno accedere.
-
-Consenti scrittura al gruppo proprietario
-    Consenti l'accesso in scrittura ai membri del gruppo proprietario.
-
-Consenti lettura a tutti
-    Accesso in lettura a chiunque si connetta al sistema, anche da reti pubbliche.
 
 Accesso web
 -----------
 
-Nella scheda Accesso web è possibile abilitare l’accesso alle cartelle
-condivise dal sito web del dominio registrato sul server in fase di
-installazione.
+Il metodo :guilabel:`Accesso web` consente la connessione di un
+*browser web* ad una cartella condivisa mediante il protocollo HTTP.
+Le risorse web sono identificate da una stringa, detta *Uniform
+Resource Locator*, o URL.
 
-Per abilitare l’accesso web mettere la spunta su abilita accesso web;
-abilitata l’opzione si può
+Per esempio, se il nome della cartella condivisa è ``docs`` gli URL
+per accedervi potrebbero essere: ::
 
-*  Personalizzare il percorso per accedere alla cartella condivisa
-   scegliendo fra le opzioni default, radice sito web oppure
-   personalizzato, in questo caso occorre inserire il percorso nel campo
-   dedicato.
-*  Decidere se riservare l’accesso solo dalle reti locali, in tal caso
-   mettere la spunta su Consenti l'accesso solo dalle reti locali
-*  Impostare una password di accesso alla cartella condivisa.
+    http://192.168.1.1/docs
+    https://192.168.1.1/docs
+    http://myserver/docs
+    http://www.domain.com/docs
+    http://docs.domain.com/
+
+Ogni URL ha tre componenti:
+
+* protocollo (``http://`` or ``https://``),
+* nome host (``192.168.1.1``, ``myserver``, ``www.domain.com``),
+* percorso (``docs``).
+
+Il gruppo :guilabel:`Indirizzo web (URL)` definisce il componente "percorso".
+
+* :guilabel:`Nome cartella` è il default, lo stesso della cartella
+  condivisa, come ``docs`` nell'esempio precedente.
+
+* :guilabel:`Radice del sito web` significa nessun percorso. Per
+  esempio ``http://docs.domain.com``.
+
+* :guilabel:`Personalizzato` significa un nome alternativo, da specificare.
+
+Il selettore :guilabel:`Host virtuale` elenca tutti gli
+:guilabel:`Alias server` definiti nella pagina :guilabel:`DNS`.
+"Tutti" significa che il nome host non è considerato nell'associare
+l'URL alla cartella condivisa.
+
+L'accesso web è anonimo è in sola lettura.  Ci sono alcune opzioni con
+cui restringere ulteriormente il permesso di accesso.
+
+* :guilabel:`Consenti l'accesso solo dalle reti fidate`, restringe
+  l'accesso in base all'indirizzo IP del client,
+
+* :guilabel:`Richiedi la password`, limita l'accesso a chi conosce la
+  password condivisa (da specificare).
+
+* :guilabel:`Richiedi connessione SSL cifrata`.
 
 
-Host virtuale
-    Permette di scegliere da quale nome di host è accessibile la
-    cartella condivisa. L'elenco è modificabile tramite la scheda
-    "Alias server" del modulo "DNS e DHCP". 
-    
-Indirizzo web (URL)
-    Definisce l'indirizzo web a cui è disponibile la risorsa.
+Configurare un'applicazione web
+-------------------------------
 
+La casella :guilabel:`Consenti override di .htaccess e dei permessi
+di scrittura` attiva una speciale configurazione di Apache pensata per
+ospitare una semplice applicazione web in una cartella condivisa.
+Consente di modificare la configurazione di default di Apache e di
+concedere i permessi di scrittura per specifice sub-directory.
 
+.. warning:: Se una cartella condivisa contiene condice eseguibile,
+             come ad esempio script PHP, i permessi degli utenti e le
+             possibili implicazioni di sicurezza devono essere
+             vaultati attentamente.
+
+Se la casella è abilitata
+
+* i file con nome :file:`.htaccess` sono caricati come `configurazione
+  di Apache <http://httpd.apache.org/docs/2.2/howto/htaccess.html>`_.
+
+* un file di testo con nome :file:`.htwritable` posizionato nella
+  radice della cartella condivisa può contenere una lista di
+  sotto-directory dove Apache ottiene i permessi di scrittura.  La
+  sintassi del file è una sotto-directory per ogni riga.  Le righe che
+  iniziano con ``#`` sono commenti.  Quando il contenuto del file
+  :file:`.htwritable` cambia il pulsante :guilabel:`Reimposta
+  permessi` deve essere premuto di nuovo per propagare i permessi al
+  file system.
+
+.. note:: Le cartelle condivise sono uno strumento potente ma non
+          vanno intese come una soluzione completa per il web hosting!
+          Per configurare Apache e i virtual host in maniera più
+          avanzata aggiungere un file ``.conf`` sotto la directory
+          :file:`/etc/httpd/conf.d/`.  Fare riferimento alla
+          documentazione di Apache per questo.
 
 Samba
 -----
 
-Nella scheda Samba è possibile abilitare il server samba, il quale
-permette di interagire con client o server Microsoft Windows.
+SMB/CIFS è un protocollo molto diffuso che consente di condividere
+file in una rete di computer.  In un modo simile agli URL Web visti
+sopra, il nome della cartella condivisa divente il nome della
+condivisione SMB.
 
-Per abilitare Samba mettere la spunta su Abilita samba; è possibile
-abilitare il cestino di rete dove finiranno i file cancellati dalle
-cartelle condivise mettendo la spunta su Cestino di rete e decidere se
-mantenere i file omonimi all’interno del cestino.
+Per esempio, l'indirizzo di rete SMB per la condivisione ``docs``
+potrebbe essere ::
 
-Si può abilitare anche un accesso di tipo ospite alle cartelle
-condivise; se si sceglie nessuno non sarà consentito l’accesso
-ospite, se si sceglie solo lettura gli utenti ospiti potranno solamente
-aprire i file delle cartella condivisa, mentre se si sceglie lettura e
-scrittura potranno aprire e modificare i file condivisi.
+   \\192.168.1.1\docs
+   \\MYSERVER\docs
 
+I client compatibili con SMB possono essere utilizzati per impostare
+le ACL su specifici file o sotto-directory.  In ogni momento, il
+pulsante :guilabel:`Reimposta permessi` ripristina i permessi UNIX e
+POSIX secondo quanto definito nelle schede :guilabel:`Generale` e
+:guilabel:`ACL`.
 
-ACL
----
+Se l'opzione :guilabel:`Cestino di rete` è abilitata, i file rimossi
+da una cartella condivisa sono in realtà spostati in una directory
+"cestino" speciale. L'opzione :guilabel:`Mantieni file omonimi`
+assicura che i file nel cestino abbiano sempre nomi distiniti,
+impedendo la sovrascrittura.
 
-Nella scheda ACL è possibile redigere una lista ordinata di regole che
-stabiliscono quali  permessi delle cartella condivisa sono concessi ogni
-singolo utente o per un intero gruppo.
-
-Per impostare una regola inserire il nome utente o del gruppo nel campo,
-il sistema cercherà automaticamente man mano che si compila il nome.
-Scelto il nome da aggiungere fare click sul pulsante aggiungi.
-
-Viene aggiunta una riga sotto il campo dove è inserito il nome scelto e
-accanto le opzioni per impostare i permessi, mettere la spunta su
-lettura se l’utente o il gruppo deve solo poter aprire la cartella o i
-files condivisi, mettere la spunta su lettura e  scrittura se l'utente o
-il gruppo può aprire e modificare la cartella o i files condivisi.
-
-Per cancellare una regola fare click sulla **X** a destra della riga
-contenente il nome dell’ utente o del gruppo.
-
-Eliminazione
-============
-
-Per eliminare una cartella condivisa fare click sulla freccia adiacente
-il pulsante modifica. Si apre un menù a tendina, fare click sulla voce
-elimina. Verrà chiesta la conferma, fare click sul pulsante elimina per
-eliminare definitivamente la cartella.
-
-
-Rimuove la cartella e tutto il suo contenuto.
-In caso di eliminazione accidentale, è possibile recuperare
-il contenuto della cartella ripristinandola da un backup.
-
-.. warning:: L'eliminazione di una cartella condivisa è irreversibile.
-
-Reimposta permessi
-==================
-
-Imposta ai valori configurati tramite questo modulo il gruppo
-proprietario e le ACL. L'operazione sarà eseguita ricorsivamente su
-tutti i file e le sottocartelle della cartella condivisa.
+Se è attiva l'opzione :guilabel:`Accesso guest`, sono considerate valide
+qualsiasi credenziali vengano presentate.
 
 


### PR DESCRIPTION
The old Shared Folders page was a copy of the online manual page. This is a complete review, including .htwritable, .htaccess feature explanation.