### PR TITLE
typos - text formatting: undo change in line 293

### DIFF
--- a/developer-manual/en/templates.rst
+++ b/developer-manual/en/templates.rst
@@ -290,7 +290,7 @@ Requesting expansion of a template in an event is a simple matter of
 creating an empty file under the ``templates2expand`` hierarchy for that
 event. 
 
-See [Events manual chapter](http://docs.nethserver.org/projects/nethserver-devel/en/latest/events.html#events) for further information.
+See :ref:`events` manual chapter for further information.
 
 Template permissions and ownership: templates.metadata
 ======================================================
@@ -354,7 +354,7 @@ output filename is variable:
         processTemplate(
         {
           TEMPLATE_PATH => "/etc/myservice/user.conf",
-          OUTPUT_FILENAME => "/etc/myservice/$name.conf
+          OUTPUT_FILENAME => "/etc/myservice/$name.conf"
         );
         [...]
     }


### PR DESCRIPTION
change in line 293 undone: Link not displayed properly within ReadTheDocs.
Markdown link replaced with a :ref: placeholder.